### PR TITLE
Add prefix functionality to scopes to facilitate multiple state machines on one model.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project aims to adhere to [Semantic Versioning](http://semver.org/spec/
 ### Removed <!-- for now removed features. -->
 ### Fixed <!-- for any bug fixes. -->
 
+## [1.2.0] - 2024-06-14
+### Added
+- Added ability for scopes to use a named prefix, which will be useful when
+  dealing with multiple state machines on one object.
+
 ## [1.1.0] - 2023-12-29
 ### Added
 - Added testing support for Ruby 3.2.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    steady_state (1.1.0)
+    steady_state (1.2.0)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,27 @@ steady_state :step, scopes: false do
 end
 ```
 
+### Prefixed Scopes
+
+On ActiveRecord objects, you may optionally define a prefix for your scope.  This may be useful when dealing with multiple state machines on one object.
+
+```ruby
+steady_state :state, scopes: true do
+  state 'solid', default: true
+  state 'liquid', from: 'solid'
+  # ...
+end
+
+steady_state :temperature, scopes: true, scopes_prefix: 'temperature' do
+  state 'cold', default: true
+  state 'warm', from: 'cold'
+  # ...
+end
+
+Material.solid # => query for 'solid' records
+Material.temperature_cold # => query for 'cold' records
+```
+
 ### Next and Previous States
 
 The `may_become?` method can be used to see if setting the state to a particular value would be allowed (ignoring all other validations):
@@ -277,7 +298,7 @@ class Material
     self.state = 'liquid'
     valid? # will return `false` if state transition is invalid
   end
-  
+
   def melt!
     self.state = 'liquid'
     validate! # will raise an exception if state transition is invalid

--- a/README.md
+++ b/README.md
@@ -210,25 +210,20 @@ steady_state :step, scopes: false do
 end
 ```
 
-### Prefixed Scopes
-
-On ActiveRecord objects, you may optionally define a prefix for your scope.  This may be useful when dealing with multiple state machines on one object.
+`steady_state` also follows the same `prefix` api as `delegate` in Rails.  You may optionally define your scopes to be prefixed to the name of the state machine with `prefix: true`, or you may provide a custom prefix with `prefix: :some_custom_name`.  This may be useful when dealing with multiple state machines on one object.
 
 ```ruby
-steady_state :state, scopes: true do
-  state 'solid', default: true
-  state 'liquid', from: 'solid'
-  # ...
+steady_state :temperature, scopes: true, prefix: true do
+  state 'cold', default: true
 end
 
-steady_state :temperature, scopes: true, scopes_prefix: 'temperature' do
-  state 'cold', default: true
-  state 'warm', from: 'cold'
-  # ...
+steady_state :conductivity, scopes: true, prefix: :sigma do
+  state 'conductive', default: true
 end
 
 Material.solid # => query for 'solid' records
 Material.temperature_cold # => query for 'cold' records
+Material.sigma_conductive # => query for 'conductive' records
 ```
 
 ### Next and Previous States

--- a/README.md
+++ b/README.md
@@ -213,17 +213,17 @@ end
 `steady_state` also follows the same `prefix` api as `delegate` in Rails.  You may optionally define your scopes to be prefixed to the name of the state machine with `prefix: true`, or you may provide a custom prefix with `prefix: :some_custom_name`.  This may be useful when dealing with multiple state machines on one object.
 
 ```ruby
-steady_state :temperature, scopes: true, prefix: true do
+steady_state :temperature, scopes: { prefix: true } do
   state 'cold', default: true
 end
 
-steady_state :conductivity, scopes: true, prefix: :sigma do
-  state 'conductive', default: true
+steady_state :color_temperature, scopes: { prefix: 'color' } do
+  state 'cold', default: true
 end
 
 Material.solid # => query for 'solid' records
-Material.temperature_cold # => query for 'cold' records
-Material.sigma_conductive # => query for 'conductive' records
+Material.temperature_cold # => query for records with a cold temperature
+Material.color_cold # => query for for records with a cold color temperature
 ```
 
 ### Next and Previous States

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    steady_state (1.1.0)
+    steady_state (1.2.0)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
 
@@ -104,10 +104,10 @@ GEM
     zeitwerk (2.6.15)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
-  arm64-darwin-22
 
 DEPENDENCIES
   activemodel (~> 6.1.0)

--- a/gemfiles/rails_7_0.gemfile.lock
+++ b/gemfiles/rails_7_0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    steady_state (1.1.0)
+    steady_state (1.2.0)
       activemodel (>= 5.2)
       activesupport (>= 5.2)
 
@@ -102,10 +102,10 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
-  arm64-darwin-22
 
 DEPENDENCIES
   activemodel (~> 7.0.0)

--- a/lib/steady_state/attribute.rb
+++ b/lib/steady_state/attribute.rb
@@ -68,5 +68,9 @@ module SteadyState
                                    inclusion: { in: state_machines[attr_name].states }
       end
     end
+
+    def self.build_prefix(attr_name, prefix: false)
+      prefix ? "#{prefix == true ? attr_name : prefix}_" : ""
+    end
   end
 end

--- a/lib/steady_state/attribute.rb
+++ b/lib/steady_state/attribute.rb
@@ -15,7 +15,7 @@ module SteadyState
     end
 
     class_methods do
-      def steady_state(attr_name, predicates: true, states_getter: true, scopes: SteadyState.active_record?(self), prefix: false, &block) # rubocop:disable Metrics/
+      def steady_state(attr_name, predicates: true, states_getter: true, scopes: SteadyState.active_record?(self), &block) # rubocop:disable Metrics/
         overrides = Module.new do
           define_method :"validate_#{attr_name}_transition_to" do |next_value|
             if public_send(attr_name).may_become?(next_value)
@@ -55,15 +55,15 @@ module SteadyState
         end
 
         delegate(*state_machines[attr_name].predicates, to: attr_name, allow_nil: true) if predicates
-
         if scopes
-          scope_prefix = if prefix
-                           "#{prefix == true ? attr_name : prefix}_"
-                         else
-                           ""
-                         end
+          prefix = if scopes == true
+                     ''
+                   elsif scopes.is_a?(Hash) && scopes[:prefix]
+                     "#{scopes[:prefix] == true ? attr_name : scopes[:prefix]}_"
+                   end
+
           state_machines[attr_name].states.each do |state|
-            scope :"#{scope_prefix}#{state}", -> { where(attr_name.to_sym => state) }
+            scope :"#{prefix}#{state}", -> { where(attr_name.to_sym => state) }
           end
         end
 

--- a/lib/steady_state/attribute.rb
+++ b/lib/steady_state/attribute.rb
@@ -56,7 +56,7 @@ module SteadyState
 
         delegate(*state_machines[attr_name].predicates, to: attr_name, allow_nil: true) if predicates
         if scopes
-          scopes = scopes.is_a?(Hash) ? scopes : {}
+          scopes = {} unless scopes.is_a?(Hash)
           prefix = SteadyState::Attribute.build_prefix(attr_name, **scopes)
 
           state_machines[attr_name].states.each do |state|
@@ -70,7 +70,11 @@ module SteadyState
     end
 
     def self.build_prefix(attr_name, prefix: false)
-      prefix ? "#{prefix == true ? attr_name : prefix}_" : ""
+      if prefix
+        "#{prefix == true ? attr_name : prefix}_"
+      else
+        ""
+      end
     end
   end
 end

--- a/lib/steady_state/attribute.rb
+++ b/lib/steady_state/attribute.rb
@@ -56,11 +56,8 @@ module SteadyState
 
         delegate(*state_machines[attr_name].predicates, to: attr_name, allow_nil: true) if predicates
         if scopes
-          prefix = if scopes == true
-                     ''
-                   elsif scopes.is_a?(Hash) && scopes[:prefix]
-                     "#{scopes[:prefix] == true ? attr_name : scopes[:prefix]}_"
-                   end
+          scopes = scopes.is_a?(Hash) ? scopes : {}
+          prefix = SteadyState::Attribute.build_prefix(attr_name, **scopes)
 
           state_machines[attr_name].states.each do |state|
             scope :"#{prefix}#{state}", -> { where(attr_name.to_sym => state) }

--- a/lib/steady_state/version.rb
+++ b/lib/steady_state/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SteadyState
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/steady_state/attribute_spec.rb
+++ b/spec/steady_state/attribute_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe SteadyState::Attribute do
     end
 
     context 'enabled with prefix: true' do
-      let(:opts) { { scopes: true, prefix: true } }
+      let(:opts) { { scopes: { prefix: true } } }
 
       it 'defines a scope for each state, prefixed with the name of the state machine' do
         expect(steady_state_class.defined_scopes.keys).to eq %i(car_driving car_stopped car_parked)
@@ -410,7 +410,7 @@ RSpec.describe SteadyState::Attribute do
     end
 
     context 'enabled with a custom prefix such as prefix: :automobile' do
-      let(:opts) { { scopes: true, prefix: :automobile } }
+      let(:opts) { { scopes: { prefix: :automobile } } }
 
       it 'defines a scope for each state with the custom prefix' do
         expect(steady_state_class.defined_scopes.keys).to eq %i(automobile_driving automobile_stopped automobile_parked)

--- a/spec/steady_state/attribute_spec.rb
+++ b/spec/steady_state/attribute_spec.rb
@@ -394,10 +394,10 @@ RSpec.describe SteadyState::Attribute do
       end
     end
 
-    context 'enabled with custom scope prefix' do
-      let(:opts) { { scopes: true, scopes_prefix: 'car' } }
+    context 'enabled with prefix: true' do
+      let(:opts) { { scopes: true, prefix: true } }
 
-      it 'defines a scope for each state with the prefix' do
+      it 'defines a scope for each state, prefixed with the name of the state machine' do
         expect(steady_state_class.defined_scopes.keys).to eq %i(car_driving car_stopped car_parked)
 
         expect(query_object).to receive(:where).with(car: 'driving')
@@ -406,6 +406,21 @@ RSpec.describe SteadyState::Attribute do
         query_object.instance_exec(&steady_state_class.defined_scopes[:car_stopped])
         expect(query_object).to receive(:where).with(car: 'parked')
         query_object.instance_exec(&steady_state_class.defined_scopes[:car_parked])
+      end
+    end
+
+    context 'enabled with a custom prefix such as prefix: :automobile' do
+      let(:opts) { { scopes: true, prefix: :automobile } }
+
+      it 'defines a scope for each state with the custom prefix' do
+        expect(steady_state_class.defined_scopes.keys).to eq %i(automobile_driving automobile_stopped automobile_parked)
+
+        expect(query_object).to receive(:where).with(car: 'driving')
+        query_object.instance_exec(&steady_state_class.defined_scopes[:automobile_driving])
+        expect(query_object).to receive(:where).with(car: 'stopped')
+        query_object.instance_exec(&steady_state_class.defined_scopes[:automobile_stopped])
+        expect(query_object).to receive(:where).with(car: 'parked')
+        query_object.instance_exec(&steady_state_class.defined_scopes[:automobile_parked])
       end
     end
 

--- a/spec/steady_state/attribute_spec.rb
+++ b/spec/steady_state/attribute_spec.rb
@@ -394,6 +394,21 @@ RSpec.describe SteadyState::Attribute do
       end
     end
 
+    context 'enabled with custom scope prefix' do
+      let(:opts) { { scopes: true, scopes_prefix: 'car' } }
+
+      it 'defines a scope for each state with the prefix' do
+        expect(steady_state_class.defined_scopes.keys).to eq %i(car_driving car_stopped car_parked)
+
+        expect(query_object).to receive(:where).with(car: 'driving')
+        query_object.instance_exec(&steady_state_class.defined_scopes[:car_driving])
+        expect(query_object).to receive(:where).with(car: 'stopped')
+        query_object.instance_exec(&steady_state_class.defined_scopes[:car_stopped])
+        expect(query_object).to receive(:where).with(car: 'parked')
+        query_object.instance_exec(&steady_state_class.defined_scopes[:car_parked])
+      end
+    end
+
     context 'disabled' do
       let(:opts) { { scopes: false } }
 


### PR DESCRIPTION
When using multiple state machines on a single model, one might want more control over their scopes.  In order to allow that, this PR adds handling a hash with some prefix options that works similar to how delegate in rails works.  You can pass in `scopes: { prefix: true }` to get your scope prefixed with your attribute or `scopes: { prefix: 'some_custom_prefix' }` to get your scope prefixed with a custom prefix.

This PR also adds associated tests and updates the Readme.